### PR TITLE
Add playlists thumbnails to the menu when selecting

### DIFF
--- a/rofi_spotify/rofi_spotify.py
+++ b/rofi_spotify/rofi_spotify.py
@@ -8,15 +8,20 @@ import subprocess
 import sys
 import textwrap
 import time
+from pathlib import Path
+import requests
 
 import appdirs
 import spotipy
 from rofi import Rofi
 
+THUMBSDIR = Path.home() / ".cache" / "rofi-spotify" / "thumbs"
 
 def load_config():
     config_dir = appdirs.user_config_dir('rofi-spotify')
     config_path = os.path.join(config_dir, 'rofi-spotify.conf')
+
+    THUMBSDIR.mkdir(parents=True, exist_ok=True)
 
     if os.path.exists(config_path):
         config = configparser.ConfigParser()
@@ -118,6 +123,14 @@ def addTrackToPlaylist(rofi, rofi_args, sp, username, playlist_id, playlist_name
     return sp.user_playlist_add_tracks(username, playlist_id, {track_id}) 
 
 
+def findAppropriateThumbnailSource(images, lower=50, upper=500):
+    images = sorted(images, key=lambda i: i["height"])
+    matching = filter(lambda i: lower <= (i.get("height") or -1) <= upper, images),
+    
+    # If the condition can't be satisfied, return a middle ground
+    return (matching[-1] if matching else images[int(len(images)/2)])["url"]
+
+
 def run():
     config, config_dir = load_config()
 
@@ -128,6 +141,7 @@ def run():
     parser.add_argument('-i', '--case-sensitive', action='store_true', help='Enable case sensitivity')
     parser.add_argument('-r', '--args', nargs=argparse.REMAINDER, help='Command line arguments for rofi. '
                                                                        'Separate each argument with a space.')
+    parser.add_argument(      '--clear-cache', action='store_true', help='Clear the downloaded thumbnails cache',)
     args = parser.parse_args()
 
     rofi_args = args.args or []
@@ -141,13 +155,32 @@ def run():
                                                                   client_secret=config['spotipy']['client_secret'],
                                                                   redirect_uri=config['spotipy']['redirect_uri'],
                                                                   scope=scope, cache_path=(config_dir + "/token")))
+    if args.clear_cache:
+        [thumb.unlink() for thumb in THUMBSDIR.glob("*.png")]
+        return
 
     if args.add_to_playlist:
         track_id, track_meta = getCurrentTrack(sp)
         playlists = getPlaylists(sp, onlyEditable=True, username=config['spotify']['spotify_username'])
-        playlists_names = [d['name'] for d in playlists['items']]
-        index, key = rofi.select("To which playlist do you want to add " + track_meta + "? ",
-                                 playlists_names, rofi_args=rofi_args)
+        for playlist in playlists["items"]:
+            file = THUMBSDIR / (playlist["id"] + ".png")
+            if not file.exists():
+                rofi.status(f"Downloading thumbnail for playlist {playlist['name']}")
+                file.write_bytes(
+                    requests.get(
+                        findAppropriateThumbnailSource(playlist["images"])
+                    ).content
+                )
+
+        playlists_names = [
+            d["name"] + "\0icon\x1f" + str(THUMBSDIR / (d["id"] + ".png"))
+            for d in playlists["items"]
+        ]
+        index, key = rofi.select(
+            "To which playlist do you want to add " + track_meta + "? ",
+            playlists_names,
+            rofi_args=rofi_args,
+        )
         if key == -1:
             sys.exit(0)
         target_playlist_id = playlists['items'][index]['id']

--- a/rofi_spotify/rofi_spotify.py
+++ b/rofi_spotify/rofi_spotify.py
@@ -8,15 +8,20 @@ import subprocess
 import sys
 import textwrap
 import time
+from pathlib import Path
+import requests
 
 import appdirs
 import spotipy
 from rofi import Rofi
 
+THUMBSDIR = Path.home() / ".cache" / "rofi-spotify" / "thumbs"
 
 def load_config():
     config_dir = appdirs.user_config_dir('rofi-spotify')
     config_path = os.path.join(config_dir, 'rofi-spotify.conf')
+
+    THUMBSDIR.mkdir(parents=True, exist_ok=True)
 
     if os.path.exists(config_path):
         config = configparser.ConfigParser()
@@ -118,6 +123,14 @@ def addTrackToPlaylist(rofi, rofi_args, sp, username, playlist_id, playlist_name
     return sp.user_playlist_add_tracks(username, playlist_id, {track_id}) 
 
 
+def findAppropriateThumbnailSource(images, lower=50, upper=500):
+    images = sorted(images, key=lambda i: i["height"])
+    matching = filter(lambda i: lower <= (i.get("height") or -1) <= upper, images),
+    
+    # If the condition can't be satisfied, return a middle ground
+    return (matching[-1] if matching else images[int(len(images)/2)])["url"]
+
+
 def run():
     config, config_dir = load_config()
 
@@ -127,7 +140,7 @@ def run():
     parser.add_argument("-st", "--search-track", action="store_true", help="Search for a track")
     parser.add_argument('-i', '--case-sensitive', action='store_true', help='Enable case sensitivity')
     parser.add_argument('-r', '--args', nargs=argparse.REMAINDER, help='Command line arguments for rofi. '
-                                                                       'Separate each argument with a space.')
+    parser.add_argument(      '--clear-cache', action='store_true', help='Clear the downloaded thumbnails cache',)
     args = parser.parse_args()
 
     rofi_args = args.args or []
@@ -141,13 +154,32 @@ def run():
                                                                   client_secret=config['spotipy']['client_secret'],
                                                                   redirect_uri=config['spotipy']['redirect_uri'],
                                                                   scope=scope, cache_path=(config_dir + "/token")))
+    if args.clear_cache:
+        [thumb.unlink() for thumb in THUMBSDIR.glob("*.png")]
+        return
 
     if args.add_to_playlist:
         track_id, track_meta = getCurrentTrack(sp)
         playlists = getPlaylists(sp, onlyEditable=True, username=config['spotify']['spotify_username'])
-        playlists_names = [d['name'] for d in playlists['items']]
-        index, key = rofi.select("To which playlist do you want to add " + track_meta + "? ",
-                                 playlists_names, rofi_args=rofi_args)
+        for playlist in playlists["items"]:
+            file = THUMBSDIR / (playlist["id"] + ".png")
+            if not file.exists():
+                rofi.status(f"Downloading thumbnail for playlist {playlist['name']}")
+                file.write_bytes(
+                    requests.get(
+                        findAppropriateThumbnailSource(playlist["images"])
+                    ).content
+                )
+
+        playlists_names = [
+            d["name"] + "\0icon\x1f" + str(THUMBSDIR / (d["id"] + ".png"))
+            for d in playlists["items"]
+        ]
+        index, key = rofi.select(
+            "To which playlist do you want to add " + track_meta + "? ",
+            playlists_names,
+            rofi_args=rofi_args,
+        )
         if key == -1:
             sys.exit(0)
         target_playlist_id = playlists['items'][index]['id']


### PR DESCRIPTION

![screenshot](https://user-images.githubusercontent.com/39094199/153775698-a3772965-1d43-4a3e-af28-2135f8f43833.png)

_Using theme [Launchpad](https://github.com/lr-tech/rofi-themes-collection#launchpad)_

---

It's not very well documented, but you can give a rofi selection row an icon by appending `\0icon\x1fPATH_TO_ICON` to a choice.

Since we have access to thumbnail URLs through the API, I added some code that downloads playlist thumbnails to a cache, and uses them.

It notifies the user that thumbnails are being downloaded, as the first use will take some time (all of the thumbnails will need to be cached).
On subsequent uses, the images will already be downloaded and thus will not need to be downloaded.
Downloads will only occur when new playlist(s) have been created since the last run.

As playlist thumbnails can change, the user can clear the downloaded thumbnails with `--clear-cache` to download them again.
(a way to periodically refresh thumbnails based on the last download time can be quite easily implemented, but I'm not sure if it is worth the added delays when thumbnails eventually get re-downloaded)

The thumbnails are stored in `$HOME/.cache/rofi-spotify/thumbs/` as `PLAYLIST_ID.png`. Here again, it should be pretty simple to make this download location customizable in the configuration.

The only thing I still need to do is update the documentation.